### PR TITLE
Renamed unused variable _ to dummy to resolve conflict with i18n._

### DIFF
--- a/gbpservice/neutron/nsf/lifecycle_manager/drivers/haproxy_lifecycle_driver.py
+++ b/gbpservice/neutron/nsf/lifecycle_manager/drivers/haproxy_lifecycle_driver.py
@@ -63,7 +63,8 @@ class HaproxyLifeCycleDriver(LifeCycleDriverBase):
                 try:
                     port_id = self._get_port_id(port, token)
                     (provider_ip, provider_mac,
-                     provider_cidr, _) = self._get_port_details(token, port_id)
+                     provider_cidr, dummy) = self._get_port_details(token,
+                                                                    port_id)
                 except Exception:
                     LOG.error(_('Failed to get provider port details'
                                 ' for get device config info operation'))

--- a/gbpservice/neutron/nsf/lifecycle_manager/drivers/vyos_lifecycle_driver.py
+++ b/gbpservice/neutron/nsf/lifecycle_manager/drivers/vyos_lifecycle_driver.py
@@ -59,7 +59,8 @@ class VyosLifeCycleDriver(LifeCycleDriverBase):
                 try:
                     port_id = self._get_port_id(port, token)
                     (provider_ip, provider_mac,
-                     provider_cidr, _) = self._get_port_details(token, port_id)
+                     provider_cidr, dummy) = self._get_port_details(token,
+                                                                    port_id)
                 except Exception:
                     LOG.error(_('Failed to get provider port details'
                                 ' for get device config info operation'))


### PR DESCRIPTION
Pylint allows unused variables names that start with _ or dummy (Ref: https://docs.pylint.org/faq.html#i-have-a-callback-function-where-i-have-no-control-over-received-arguments-how-do-i-avoid-getting-unused-argument-warnings)

@mageshgv-oc, Is it the right way to resolve such conflicts. To support PEP8 standards and to bypass PyLint warnings.