### PR TITLE
Fix for the stale OVS ports

### DIFF
--- a/gbpservice/nfp/orchestrator/drivers/orchestration_driver_base.py
+++ b/gbpservice/nfp/orchestrator/drivers/orchestration_driver_base.py
@@ -500,7 +500,7 @@ class OrchestrationDriverBase(object):
                 self.compute_handler_nova.delete_instance(
                                                 token,
                                                 self._get_admin_tenant_id(
-                                                                    token=token),
+                                                                token=token),
                                                 device_data['id'])
             except Exception:
                 self._increment_stats_counter('instance_delete_failures')
@@ -509,7 +509,7 @@ class OrchestrationDriverBase(object):
             else:
                 self._decrement_stats_counter('instances')
         else:
-            # device instance deletion is done, delete remaining resources 
+            # device instance deletion is done, delete remaining resources
             try:
                 self._delete_interfaces(device_data,
                                         [device_data['mgmt_port_id']],

--- a/gbpservice/nfp/orchestrator/modules/device_orchestrator.py
+++ b/gbpservice/nfp/orchestrator/modules/device_orchestrator.py
@@ -497,8 +497,6 @@ class DeviceOrchestrator(PollEventDesc):
         is_device_up = (
             orchestration_driver.get_network_function_device_status(device))
         if is_device_up == nfp_constants.ACTIVE:
-            self._controller.poll_event_done(event)
-
             # create event DEVICE_UP
             self._create_event(event_id='DEVICE_UP',
                                event_data=device,
@@ -507,8 +505,6 @@ class DeviceOrchestrator(PollEventDesc):
                                                    'DEVICE_UP')
             return STOP_POLLING
         elif is_device_up == nfp_constants.ERROR:
-            self._controller.poll_event_done(event)
-
             # create event DEVICE_NOT_UP
             self._create_event(event_id='DEVICE_NOT_UP',
                                event_data=device,


### PR DESCRIPTION
The stale OVS ports on compute are because the neutron port is deleted before the nova instance is completely deleted.
Fixing this by deleting the device instance related resources only after device instance deletion is completed.
Implemented a poll event DEVICE_BEING_DELETED

Testing is going on.

@ashutosh-mishra @njagadish @hemanthravi @chandra-k @YogeshRajmane
