### PR TITLE
Temporary solution to get around visibility for lbaasv2

### DIFF
--- a/gbpservice/nfp/configurator/drivers/loadbalancer/v2/haproxy/haproxy_driver.py
+++ b/gbpservice/nfp/configurator/drivers/loadbalancer/v2/haproxy/haproxy_driver.py
@@ -347,6 +347,11 @@ class HaproxyLoadBalancerDriver(n_driver_base.LoadBalancerBaseDriver,
         self.health_monitor = HaproxyHealthMonitorManager(self)
         self.o_models_builder = OctaviaDataModelBuilder(self)
 
+    # TODO(jiahao):visibility for lbaasv2 is not implememnted.
+    # Temporary solution to get around it.
+    def _configure_log_forwarding(self, url, mgmt_ip, port):
+        return common_const.UNHANDLED
+
     @classmethod
     def get_name(self):
         return DRIVER_NAME


### PR DESCRIPTION
Visibility for lbaasv2 is not implememnted yet. If we enable visibility, the configurator will check for some visibility attribute which is not exist for lbaasv2 and raised an exception.
For now I am going to bypass the function to configure visibility.
