### PR TITLE
PEP8 fixes and review comments addressal in LB, api server and test code

### DIFF
--- a/gbpservice/contrib/nfp/configurator/api/v1/controllers/controller.py
+++ b/gbpservice/contrib/nfp/configurator/api/v1/controllers/controller.py
@@ -12,31 +12,29 @@
 
 import oslo_serialization.jsonutils as jsonutils
 
-# from neutron.agent.common import config
 from neutron.common import rpc as n_rpc
 from oslo_config import cfg
 from oslo_log import log as logging
 import oslo_messaging
 import pecan
 
-from gbpservice.contrib.nfp.configurator.api.base_controller import BaseController
+from gbpservice.contrib.nfp.configurator.api import base_controller
 
 LOG = logging.getLogger(__name__)
 n_rpc.init(cfg.CONF)
 
-"""Implements all the APIs Invoked by HTTP requests.
 
-Implements following HTTP methods.
-    -get
-    -post
-    -put
-According to the HTTP request received from config-agent this class make
-call/cast to configurator and return response to config-agent
+class Controller(base_controller.BaseController):
+    """Implements all the APIs Invoked by HTTP requests.
 
-"""
+    Implements following HTTP methods.
+        -get
+        -post
+        -put
+    According to the HTTP request received from config-agent this class make
+    call/cast to configurator and return response to config-agent
 
-
-class Controller(BaseController):
+    """
 
     def __init__(self, method_name):
         try:
@@ -195,18 +193,16 @@ class Controller(BaseController):
         return error_data
 
 
-"""Implements call/cast methods used in REST Controller.
-
-Implements following methods.
-    -call
-    -cast
-This class send an RPC call/cast to configurator according to the data sent
-by Controller class of REST server.
-
- """
-
-
 class RPCClient(object):
+    """Implements call/cast methods used in REST Controller.
+
+    Implements following methods.
+        -call
+        -cast
+    This class send an RPC call/cast to configurator according to the data sent
+    by Controller class of REST server.
+
+     """
 
     API_VERSION = '1.0'
 
@@ -263,12 +259,10 @@ class RPCClient(object):
         return {}
 
 
-""" CloudService keeps all information of uservice along with initialized
-    RPCClient object using which rpc is routed to over the cloud service.
-"""
-
-
 class CloudService(object):
+    """ CloudService keeps all information of uservice along with initialized
+        RPCClient object using which rpc is routed to over the cloud service.
+    """
 
     def __init__(self, **kwargs):
         self.service_name = kwargs.get('service_name')

--- a/gbpservice/contrib/nfp/configurator/drivers/loadbalancer/v1/haproxy/haproxy_lb_driver.py
+++ b/gbpservice/contrib/nfp/configurator/drivers/loadbalancer/v1/haproxy/haproxy_lb_driver.py
@@ -13,8 +13,8 @@
 import ast
 
 from gbpservice.contrib.nfp.configurator.drivers.base import base_driver
-from gbpservice.contrib.nfp.configurator.drivers.loadbalancer.v1.haproxy import (
-                                                    haproxy_rest_client)
+from gbpservice.contrib.nfp.configurator.drivers.loadbalancer.v1.\
+    haproxy import (haproxy_rest_client)
 from gbpservice.contrib.nfp.configurator.lib import constants as common_const
 from gbpservice.contrib.nfp.configurator.lib import lb_constants
 from gbpservice.nfp.core import log as nfp_logging

--- a/gbpservice/contrib/tests/unit/nfp/configurator/agents/test_lb_agent.py
+++ b/gbpservice/contrib/tests/unit/nfp/configurator/agents/test_lb_agent.py
@@ -12,20 +12,19 @@
 
 import mock
 
-from gbpservice.contrib.tests.unit.nfp.configurator.test_data import (
-    lb_test_data as test_data)
 from gbpservice.contrib.nfp.configurator.agents import loadbalancer_v1 as lb
 from gbpservice.contrib.nfp.configurator.lib import constants as const
 from gbpservice.contrib.nfp.configurator.lib import demuxer
 from gbpservice.contrib.nfp.configurator.modules import configurator
+from gbpservice.contrib.tests.unit.nfp.configurator.test_data import (
+    lb_test_data as test_data)
 from neutron.tests import base
-
-"""Implement test cases for LBaasRpcSender methods of loadbalancer agent.
-
-"""
 
 
 class LBaasRpcSenderTest(base.BaseTestCase):
+    """Implements test cases for LBaasRpcSender class methods of
+       loadbalancer agent.
+    """
 
     @mock.patch(__name__ + '.test_data.FakeObjects.conf')
     @mock.patch(__name__ + '.test_data.FakeObjects.sc')
@@ -127,12 +126,11 @@ class LBaasRpcSenderTest(base.BaseTestCase):
             '6350c0fd-07f8-46ff-b797-62acd23760de',
             test_data.FakeObjects()._get_context_logical_device())
 
-"""Implement test cases for RPC manager methods of loadbalancer agent.
-
-"""
-
 
 class LBaaSRpcManagerTest(base.BaseTestCase):
+    """Implements test cases for LBaaSRpcManager class methods of
+       loadbalancer agent.
+    """
 
     def __init__(self, *args, **kwargs):
         super(LBaaSRpcManagerTest, self).__init__(*args, **kwargs)
@@ -388,12 +386,11 @@ class LBaaSRpcManagerTest(base.BaseTestCase):
             self.fo.get_request_data_for_update_pool_hm(),
             self.arg_dict_health_monitor_update)
 
-"""Implement test cases for methods of EventHandler of loadbalancer agent.
-
-"""
-
 
 class LBaasEventHandlerTestCase(base.BaseTestCase):
+    """Implement test cases for LBaaSEventHandler class methods of
+       loadbalancer agent.
+    """
 
     def __init__(self, *args, **kwargs):
         super(LBaasEventHandlerTestCase, self).__init__(*args, **kwargs)
@@ -407,7 +404,6 @@ class LBaasEventHandlerTestCase(base.BaseTestCase):
         :param sc: mocked service controller object of process model framework
         :param drivers: mocked drivers object of loadbalancer object
         :param rpcmgr: mocked RPC manager object loadbalancer object
-        :param nqueue: mocked nqueue object of process model framework
 
         Returns: objects of LBaaSEventHandler of loadbalancer agent
 

--- a/gbpservice/contrib/tests/unit/nfp/configurator/api/v1/controllers/test_controller.py
+++ b/gbpservice/contrib/tests/unit/nfp/configurator/api/v1/controllers/test_controller.py
@@ -15,12 +15,14 @@ import mock
 import os
 import oslo_serialization.jsonutils as jsonutils
 import pecan
-PECAN_CONFIG_FILE = os.getcwd() + "/gbpservice/contrib/nfp/configurator/api/config.py"
+PECAN_CONFIG_FILE = (os.getcwd() +
+                     "/gbpservice/contrib/nfp/configurator/api/config.py")
 pecan.set_config(PECAN_CONFIG_FILE, overwrite=True)
-import unittest
+
 import webtest
 import zlib
 
+from neutron.tests import base
 from pecan import rest
 
 from gbpservice.contrib.nfp.configurator.api import root_controller
@@ -38,7 +40,7 @@ print the error trace.
 """
 
 
-class ControllerTestCase(unittest.TestCase, rest.RestController):
+class ControllerTestCase(base.BaseTestCase, rest.RestController):
 
     @classmethod
     def setUpClass(cls):
@@ -267,7 +269,3 @@ class ControllerTestCase(unittest.TestCase, rest.RestController):
                 '/v1/nfp/update_network_function_config',
                 expect_errors=True)
             self.assertEqual(response.status_code, 400)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/gbpservice/contrib/tests/unit/nfp/configurator/drivers/loadbalancer/test_lb_driver.py
+++ b/gbpservice/contrib/tests/unit/nfp/configurator/drivers/loadbalancer/test_lb_driver.py
@@ -12,22 +12,19 @@
 
 import mock
 
+from gbpservice.contrib.nfp.configurator.agents import loadbalancer_v1 as lb
+from gbpservice.contrib.nfp.configurator.drivers.loadbalancer.v1.\
+    haproxy import (haproxy_lb_driver as lb_driver)
+from gbpservice.contrib.nfp.configurator.drivers.loadbalancer.v1.\
+    haproxy import (haproxy_rest_client as _rest_client)
 from gbpservice.contrib.tests.unit.nfp.configurator.test_data import (
     lb_test_data as test_data)
-from gbpservice.contrib.nfp.configurator.agents import loadbalancer_v1 as lb
-from gbpservice.contrib.nfp.configurator.drivers.loadbalancer.v1.haproxy import (
-    haproxy_lb_driver as lb_driver)
-from gbpservice.contrib.nfp.configurator.drivers.loadbalancer.v1.haproxy import (
-    haproxy_rest_client as _rest_client)
 from neutron.tests import base
 from oslo_serialization import jsonutils
 
-""" Implement test cases for loadbalancer driver.
-
-"""
-
 
 class HaproxyOnVmDriverTestCase(base.BaseTestCase):
+    """ Implements test cases for haproxy loadbalancer driver. """
 
     def __init__(self, *args, **kwargs):
         super(HaproxyOnVmDriverTestCase, self).__init__(*args, **kwargs)
@@ -63,7 +60,6 @@ class HaproxyOnVmDriverTestCase(base.BaseTestCase):
         :param sc: mocked service controller object of process model framework
         :param drivers: mocked drivers object of loadbalancer object
         :param rpcmgr: mocked RPC manager object loadbalancer object
-        :param nqueue: mocked nqueue object of process model framework
 
         Returns: objects of LBaaSEventHandler of loadbalancer agent
 

--- a/gbpservice/contrib/tests/unit/nfp/configurator/lib/filter_base.py
+++ b/gbpservice/contrib/tests/unit/nfp/configurator/lib/filter_base.py
@@ -11,13 +11,12 @@
 #    under the License.
 
 
-import unittest
-
-""" Defines all the dummy resources needed for test_filter.py
-"""
+from neutron.tests import base
 
 
-class BaseTestCase(unittest.TestCase):
+class BaseTestCase(base.BaseTestCase):
+    """ Defines all the dummy resources needed for test_filter.py
+    """
     def __init__(self, *args, **kwargs):
         super(BaseTestCase, self).__init__(*args, **kwargs)
         self.service_info = {}

--- a/gbpservice/contrib/tests/unit/nfp/configurator/lib/test_demuxer.py
+++ b/gbpservice/contrib/tests/unit/nfp/configurator/lib/test_demuxer.py
@@ -10,18 +10,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import unittest
-
+from gbpservice.contrib.nfp.configurator.lib import demuxer
 from gbpservice.contrib.tests.unit.nfp.configurator.test_data import (
                                                         fw_test_data as fo)
-from gbpservice.contrib.nfp.configurator.lib import demuxer
-
-""" Implements test cases for demuxer of configurator.
-
-"""
+from neutron.tests import base
 
 
-class ServiceAgentDemuxerTestCase(unittest.TestCase):
+class ServiceAgentDemuxerTestCase(base.BaseTestCase):
+    """ Implements test cases for demuxer of configurator. """
     def __init__(self, *args, **kwargs):
         super(ServiceAgentDemuxerTestCase, self).__init__(*args, **kwargs)
         self.fo = fo.FakeObjects()

--- a/gbpservice/contrib/tests/unit/nfp/configurator/lib/test_filter.py
+++ b/gbpservice/contrib/tests/unit/nfp/configurator/lib/test_filter.py
@@ -15,11 +15,9 @@ import filter_base
 from gbpservice.contrib.nfp.configurator.lib import data_filter
 import mock
 
-"""Test class to test data_filter.py using unittest framework
-"""
-
 
 class FilterTest(filter_base.BaseTestCase):
+    """Test class to test data_filter.py using unittest framework """
     def __init__(self, *args, **kwargs):
         super(FilterTest, self).__init__(*args, **kwargs)
 

--- a/gbpservice/contrib/tests/unit/nfp/configurator/lib/test_schema_validator.py
+++ b/gbpservice/contrib/tests/unit/nfp/configurator/lib/test_schema_validator.py
@@ -12,15 +12,13 @@
 
 import gbpservice.contrib.nfp.configurator.lib.schema as schema
 import gbpservice.contrib.nfp.configurator.lib.schema_validator as sv
-import unittest
-
-
-"""SchemaResources is a helper class which contains all the dummy resources
-   needed for TestSchemaValidator class
-"""
+from neutron.tests import base
 
 
 class SchemaResources(object):
+    """SchemaResources is a helper class which contains all the dummy resources
+       needed for TestSchemaValidator class
+    """
     resource_healthmonitor = 'healthmonitor'
     resource_interfaces = 'interfaces'
     resource_routes = 'routes'
@@ -65,12 +63,11 @@ class SchemaResources(object):
                      'periodicity': 'initial'
                      }
 
-"""TestSchemaValidator is a test class to test schema_validator.py using
-   unittest framework
-"""
 
-
-class TestSchemaValidator(unittest.TestCase):
+class TestSchemaValidator(base.BaseTestCase):
+    """TestSchemaValidator is a test class to test schema_validator.py using
+       unittest framework
+    """
 
     def __init__(self, *args, **kwargs):
         super(TestSchemaValidator, self).__init__(*args, **kwargs)
@@ -179,6 +176,3 @@ class TestSchemaValidator(unittest.TestCase):
         request_data['info']['service_type'] = 'firewall'
         result = self.sv.decode(request_data, False)
         self.assertTrue(result)
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
1) Fixed pep8 warnings which arose because of configurator dir restructure
2) Addressed review comments in unit test files under nfp/configurator/lib/
   and in api server
- Moved class comments inside class
- used neutron.tests.base class instead of unittest
